### PR TITLE
feat: implementa o fluxo de autorização para rotas de url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - [X] Autenticação
 - [X] CRUD URL
 - [] Validação
-- [] AuthGuard - get, update (atualiza apenas original_url) e delete (soft delete)
+- [X] AuthGuard - get, update (atualiza apenas original_url) e delete (soft delete)
 - [] Endpoint que recebe uma url encurtada e redirecione o usuário para o url de origem e contabilize
 - [] URLOwner (url deve pertencer a um usuário quando ele estiver autenticado)
 - [] Atualizar a rota de encurtar URL para retornar o domínio

--- a/src/auth/auth.guard.spec.ts
+++ b/src/auth/auth.guard.spec.ts
@@ -1,0 +1,7 @@
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  it('should be defined', () => {
+    expect(new AuthGuard()).toBeDefined();
+  });
+});

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,0 +1,43 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { JwtPayload } from './dto/jwt-payload.interface';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+
+  private jwtSecret: string;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {
+    this.jwtSecret = this.configService.get<string>('JWT_SECRET');
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request: Request = context.switchToHttp().getRequest();
+
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+
+    try {
+      const payload: JwtPayload = await this.jwtService.verifyAsync(token, {
+        secret: this.jwtSecret,
+      });
+      request['user'] = payload;
+    } catch {
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
+
+  private extractTokenFromHeader(request: Request): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/src/auth/dto/jwt-payload.interface.ts
+++ b/src/auth/dto/jwt-payload.interface.ts
@@ -1,0 +1,6 @@
+export interface JwtPayload {
+    sub: string;
+    username: string;
+    iat: number;
+    exp: number;
+  }

--- a/src/urls/urls.controller.ts
+++ b/src/urls/urls.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { UrlsService } from './urls.service';
 import { CreateUrlDto } from './dto/create-url.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('urls')
 export class UrlsController {
@@ -11,21 +12,25 @@ export class UrlsController {
     return this.urlsService.create(createUrlDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.urlsService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.urlsService.findOne(id);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateUrlDto: CreateUrlDto) {
     return this.urlsService.update(id, updateUrlDto);
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.urlsService.remove(id);


### PR DESCRIPTION
Descrição do PR

Implementado o fluxo de autorização na aplicação, garantindo que apenas usuários autenticados possam acessar rotas protegidas. Abaixo estão os principais detalhes da implementação:

Funcionalidades principais:

Proteção de rotas com autenticação:

    AuthGuard:
        Verifica a presença e validade de um token JWT no cabeçalho Authorization.
        O token é validado utilizando o JwtService e a chave secreta (JWT_SECRET) configurada no ambiente.
        Em caso de sucesso, o payload do JWT é anexado ao objeto da requisição no campo request['user'].
        Em caso de ausência ou invalidez do token, uma exceção UnauthorizedException é lançada.

    Rotas protegidas no controlador UrlsController:
        GET /urls: Lista todas as URLs (autenticação necessária).
        GET /urls/:id: Retorna uma URL específica (autenticação necessária).
        PATCH /urls/:id: Atualiza uma URL específica (autenticação necessária).
        DELETE /urls/:id: Remove uma URL específica (autenticação necessária).

Rotas públicas:

    A rota POST /urls permanece acessível sem a necessidade de autenticação.

Classes e serviços implementados:

    AuthGuard:
        Responsável por validar o token JWT e proteger as rotas.
        Implementado como um guard global nas rotas protegidas.

    UrlsController:
        Aplicado o uso do @UseGuards(AuthGuard) nas rotas que requerem autenticação.

Validação e controle de erros:

    Tokens ausentes ou inválidos resultam em uma resposta com o status 401 Unauthorized.
    Payloads válidos são processados normalmente, permitindo o acesso às rotas protegidas.

Essa funcionalidade é essencial para proteger os endpoints sensíveis da aplicação, garantindo que somente usuários autenticados possam realizar operações de leitura, atualização e exclusão de URLs.