### PR TITLE
feat: retorna o domínio na criação da url encurtada

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [X] AuthGuard - get, update (atualiza apenas original_url) e delete (soft delete)
 - [X] Endpoint que recebe uma url encurtada e redirecione o usuário para o url de origem e contabilize
 - [X] URLOwner (url deve pertencer a um usuário quando ele estiver autenticado)
-- [] Atualizar a rota de encurtar URL para retornar o domínio
+- [X] Atualizar a rota de encurtar URL para retornar o domínio
 - [] Criar uma rota para listar as urls pertencentes ao usuário
 - [] Banco de dados
 - [] Refatoração

--- a/src/urls/dto/create-url.dto.ts
+++ b/src/urls/dto/create-url.dto.ts
@@ -11,4 +11,5 @@ export class UrlDto {
     updated_at: string
     deleted_at: string | null
     user_id?: string | null
+    domain?: string | null
 }

--- a/src/urls/urls.service.ts
+++ b/src/urls/urls.service.ts
@@ -21,7 +21,8 @@ export class UrlsService {
       created_at: now,
       updated_at: now,
       deleted_at: null,
-      user_id: userId
+      user_id: userId,
+      domain: this.domain
     }
 
     this.urls.push(newShortenedUrl)


### PR DESCRIPTION
# Descrição do PR

Este PR contém ajustes no método `create` da classe `UrlsService` e na definição da classe `UrlDto`. As mudanças visam incluir o domínio da URL encurtada no momento de sua criação e aprimorar a estrutura do DTO.

## Alterações:

### 1. Ajuste no método `create`:
- A URL encurtada criada agora inclui o campo `domain`, que é extraído do valor configurado em `process.env.SHORT_URL_DOMAIN`.
  
Isso permite associar o domínio à URL encurtada, proporcionando um controle melhor sobre os links gerados e o rastreamento de suas origens.

### 2. Ajuste na classe `UrlDto`:
- A classe `UrlDto` foi atualizada para incluir o campo `domain`.
  - `domain`: Opcional, representando o domínio associado à URL encurtada.

Essas mudanças visam melhorar o rastreamento das URLs encurtadas, permitindo associá-las a domínios específicos.

## Impacto:
- Agora é possível criar URLs encurtadas com um domínio associado, melhorando o controle sobre em qual domínio as URLs serão acessadas.
  
Essas alterações não afetam outras funcionalidades da aplicação, mas proporcionam mais flexibilidade para a criação e rastreamento das URLs.